### PR TITLE
Unknown HTTP method respond status 404

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
         "router"
     ],
     "require-dev": {
-         "phpunit/phpunit": "~4.3.5"
-        ,"theseer/phpdox":  "~0.7.0"
-        ,"phploc/phploc":   "~2.0.6"
+         "phpunit/phpunit": "~4.8.6"
+        ,"theseer/phpdox":  "~0.8.1.1"
+        ,"phploc/phploc":   "~2.1.4"
         ,"phpmd/phpmd":     "@stable"
         ,"satooshi/php-coveralls": "dev-master"
     },

--- a/src/NotFoundAction.php
+++ b/src/NotFoundAction.php
@@ -1,0 +1,34 @@
+<?php
+namespace Teto\Routing;
+
+/**
+ * NotFoundAction object
+ *
+ * @package    Teto\Routing
+ * @author     USAMI Kenta <tadsan@zonu.me>
+ * @copyright  2015 USAMI Kenta
+ * @license    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * @property-read string[] $methods
+ * @property-read string[] $split_path
+ * @property-read array    $param_pos
+ * @property-read mixed    $value
+ * @property-read string   $extension
+ * @property-read boolean  $is_wildcard
+ * @property-read string[] $available_extensions
+ */
+class NotFoundAction extends Action
+{
+    use \Teto\Object\TypedProperty;
+
+    private static $property_types = [
+        'methods'     => 'string[]', // expects any HTTP-method
+        'split_path'  => 'string[]',
+        'param_pos'   => 'array',
+        'value'       => 'mixed',
+        'param'       => 'array',
+        'extension'   => 'string',
+        'is_wildcard' => 'bool',
+        'available_extensions' => 'array',
+    ];
+}

--- a/src/Router.php
+++ b/src/Router.php
@@ -85,10 +85,9 @@ class Router
      */
     public function getNotFoundAction($method, $path)
     {
-        $split_path = explode('/', $path);
-        array_shift($split_path);
+        $split_path = array_values(array_filter(explode('/', $path), 'strlen'));
 
-        return new Action(
+        return new NotFoundAction(
             [$method],
             $split_path,
             [],

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -63,8 +63,11 @@ final class RouterTest extends \PHPUnit_Framework_TestCase
 
         return [
             ['GET', '/',                   'index',           []],
+            ['POST', '/',                  $not_found,        []],
+            ['PUT', '/',                   $not_found,        []],
             ['HEAD', '/',                  'index',           []],
             ['GET', '/foo',                $not_found,        []],
+            ['DELETE', '/foo',             $not_found,        []],
             ['GET', '/@foo',               'show_user',       ['user' => 'foo']],
             ['GET', '/@foo.json',          $not_found,        []],
             ['GET', '/@foo/works',         'show_user_works', ['user' => 'foo']],


### PR DESCRIPTION
If the HTTP method that you do not know came, it should return `404 NotFound`.
However, type of `Action->methods` is so `enum[]`, in fact `InvalidArgumentException` is thrown.

I have defined a `NotFoundAction` class .
Type of `NotFoundAction->methods` is `string[]`.

see https://github.com/zonuexe/php-objectsystem/blob/master/poem.ja.md
